### PR TITLE
feat: made action names more informative

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -99,9 +99,11 @@ export default function addReactNDevTools<
       });
     }
     else {
+      const changedKeys = Object.keys(stateChange)
+      const changeTarget = changedKeys.length > 1 ? 'GLOBAL' : changedKeys[0].toUpperCase()
       store.dispatch({
-        stateChange,
-        type: 'STATE_CHANGE',
+          stateChange: stateChange,
+          type: `${changeTarget}_CHANGE`,
       });
     }
     return null;


### PR DESCRIPTION
If the action was not called by the reducer, then the action had the name STATE_CHANGE. 
Now, if one key has changed (for example, to use Global ("key")), the action will have a name similar to KEY_CHANGE, and if more than one key has changed, the name will be GLOBAL_CHANGE.
Demo: [screenshot](http://prntscr.com/oo47qc)